### PR TITLE
Fix run_time_dependent_d3d.jl so it runs from the command line

### DIFF
--- a/scripts/time_dependent_d3d/README.md
+++ b/scripts/time_dependent_d3d/README.md
@@ -1,0 +1,39 @@
+# Time-dependent postdictive D3D simulation
+
+`run_time_dependent_d3d.jl` runs a postdictive time-dependent simulation of a
+DIII-D shot (`FUSE.StudyPostdictive`): it fetches the experimental data
+(EFIT/profiles/CER/NBI via OMAS + OMFIT), fits profiles, and runs
+`ActorDynamicPlasma`, saving `dd_sim` / `dd_exp` / `dd_benchmark`.
+
+## Run it
+
+With a host FUSE install:
+
+```bash
+julia run_time_dependent_d3d.jl 168830 --EFIT_TREE=EFIT02
+```
+
+On omega with the FUSE container (no install; requires the fuse >= v1.1.6
+image, which ships the ssh client the D3D data fetch needs), as a batch job:
+
+```bash
+sbatch run_time_dependent_d3d.sbatch 168830 --EFIT_TREE=EFIT02
+```
+
+Data for each shot is fetched once and cached (`--USE_LOCAL_CACHE=true`, the
+default); reruns skip the fetch. See `run_time_dependent_d3d.jl --help` for
+all options.
+
+## Environment knobs
+
+| Variable | Purpose |
+|----------|---------|
+| `FUSE_RESULT_ARCHIVE` | Where result folders are saved (sbatch default: `./results`). |
+| `FUSE_DATA_CACHE` | Shot-data cache dir for the sbatch wrapper (default: `./cache`). |
+| `FUSE_SERVER` | Cluster the study runs on (default `localhost`). |
+| `FUSE_OMFIT_HOST` | Host used for remote D3D data fetching (default `somega.gat.com`; needs a `user` entry in `~/.ssh/config`). |
+| `FUSE_SCRATCH` | Scratch path on the fetch host. |
+
+A full shot (~450 MB of results + ~200 MB cache) is heavy for a home
+directory — on omega point `FUSE_RESULT_ARCHIVE`/`FUSE_DATA_CACHE` at project
+space.

--- a/scripts/time_dependent_d3d/run_time_dependent_d3d.jl
+++ b/scripts/time_dependent_d3d/run_time_dependent_d3d.jl
@@ -7,60 +7,45 @@ import FUSE
 using Distributed # part of Julia standard library so doesn't need to be in Project.toml
 using ArgParse
 
+@everywhere import FUSE
+@everywhere ProgressMeter = FUSE.ProgressMeter
+
 function main()
     s = ArgParseSettings()
     @add_arg_table! s begin
-        """
-        shot
-        """
+        "shot"
         help = "Shot number"
         arg_type = Int
         required = true
-        """
-        --EFIT_TREE
-        """
+        "--EFIT_TREE"
         help = "Source of LCFS shape"
         arg_type = String
         default = "EFIT02"
-        """
-        --PROFILES_TREE
-        """
+        "--PROFILES_TREE"
         help = "Source of profile data"
         arg_type = String
         default = "ZIPFIT01"
-        """
-        --CER_ANALYSIS_TYPE
-        """
+        "--CER_ANALYSIS_TYPE"
         help = "CER analysis type, either CERQUICK, CERAUTO, CERFAST"
         arg_type = String
         default = "CERQUICK"
-        """
-        --EFIT_RUN_ID
-        """
+        "--EFIT_RUN_ID"
         help = "Run ID for EFIT Tree, only last two digits"
         arg_type = String
         default = ""
-        """
-        --PROFILES_RUN_ID
-        """
+        "--PROFILES_RUN_ID"
         help = "Run ID for OMFIT_PROFS Tree, only last three digits"
         arg_type = String
         default = ""
-        """
-        --RECONSTRUCTION
-        """
+        "--RECONSTRUCTION"
         help = "Run time dependent simulation in reconstruction mode"
         arg_type = Bool
         default = true
-        """
-        --FIT_PROFILES
-        """
+        "--FIT_PROFILES"
         help = "Let FUSE fit the raw data into profiles"
         arg_type = Bool
         default = true
-        """
-        --USE_LOCAL_CACHE
-        """
+        "--USE_LOCAL_CACHE"
         help = "Use local data cache"
         arg_type = Bool
         default = true
@@ -85,9 +70,10 @@ function main()
         :EFIT_run_id=>args["EFIT_RUN_ID"],
         :PROFILES_run_id=>args["PROFILES_RUN_ID"])
 
-    @everywhere import FUSE
-    @everywhere ProgressMeter = FUSE.ProgressMeter
-
     study = FUSE.StudyPostdictive(sty)
     FUSE.run(study)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
 end

--- a/scripts/time_dependent_d3d/run_time_dependent_d3d.sbatch
+++ b/scripts/time_dependent_d3d/run_time_dependent_d3d.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Postdictive time-dependent D3D simulation in the FUSE container (omega).
+# Submit from this directory:  sbatch run_time_dependent_d3d.sbatch <shot> [extra args...]
+# Requires the fuse >= v1.1.6 image (in-container ssh for the D3D data fetch).
+#SBATCH -J fuse-postdictive
+#SBATCH -p medium
+#SBATCH -t 1:00:00
+#SBATCH -c 16
+#SBATCH --mem=64G
+
+if [[ -z "${1:-}" ]]; then
+    echo "usage: sbatch run_time_dependent_d3d.sbatch <shot> [extra script args...]" >&2
+    exit 2
+fi
+
+# Where results and the per-shot data cache land; override before sbatch if
+# desired (home-quota users: point these at project space).
+export SINGULARITYENV_FUSE_RESULT_ARCHIVE="${FUSE_RESULT_ARCHIVE:-$SLURM_SUBMIT_DIR/results}"
+export SINGULARITYENV_TMPDIR="${FUSE_DATA_CACHE:-$SLURM_SUBMIT_DIR/cache}"
+mkdir -p "$SINGULARITYENV_FUSE_RESULT_ARCHIVE" "$SINGULARITYENV_TMPDIR"
+
+/fusion/projects/dt/fuse_containers/fuse-container --threads="$SLURM_CPUS_PER_TASK" \
+    "$SLURM_SUBMIT_DIR/run_time_dependent_d3d.jl" "$1" "${@:2}"


### PR DESCRIPTION
The postdictive time-dependent D3D entry script had three blockers that prevented it from ever running:

1. `@everywhere import FUSE` / `@everywhere ProgressMeter = ...` inside `main()` — `@everywhere` with an `import` expands to a top-level-only expression, so the whole file fails to parse (`syntax: "toplevel" expression not at top level`). Moved both to top level.
2. Argument names in the `@add_arg_table!` block were triple-quoted strings containing newlines, which ArgParse rejects (`illegal metavar name: shot (contains whitespace)`). Converted to plain `"shot"`, `"--EFIT_TREE"`, etc.
3. `main()` was defined but never called. Added the `abspath(PROGRAM_FILE) == @__FILE__` guard.

Also adds an sbatch wrapper for running it through the omega FUSE container (`sbatch run_time_dependent_d3d.sbatch <shot>`; needs the fuse >= v1.1.6 image for in-container data fetching) and a README covering usage and the environment knobs.

Validated end to end on omega: shot 168830 — data fetch, FitProfiles, ActorDynamicPlasma, and benchmark completed in under 5 min wall on 16 CPUs, results saved (`dd_sim`/`dd_exp`/`dd_benchmark`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
